### PR TITLE
Reduce the SVN command idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The `config` command groups configuration settings by a command.
 - The `changelog` command will show actually used app version instead of `Unreleased` word, when used version isn't mentioned in a changelog. 
+- The executed SVN command idle timeout changed from 20 minutes to 3 minutes.
 
 ### Fixed
 - The non-merged revision table was shown after a successful auto-commit, when merge conflict was resolved.

--- a/src/SVNBuddy/Repository/Connector/Command.php
+++ b/src/SVNBuddy/Repository/Connector/Command.php
@@ -213,7 +213,7 @@ class Command
 	 */
 	private function _doRun($callback = null)
 	{
-		$process = $this->_processFactory->createProcess($this->_commandLine, 1200);
+		$process = $this->_processFactory->createProcess($this->_commandLine, 180); // Idle timeout: 3 minutes.
 		$command_string = (string)$this;
 
 		try {

--- a/tests/SVNBuddy/Repository/Connector/CommandFactoryTest.php
+++ b/tests/SVNBuddy/Repository/Connector/CommandFactoryTest.php
@@ -73,9 +73,9 @@ class CommandFactoryTest extends AbstractTestCase
 
 		// To get nice exception back when unexpected command is executed.
 		$this->_processFactory
-			->createProcess(Argument::any(), 1200)
+			->createProcess(Argument::any(), 180)
 			->will(function (array $args) {
-				throw new \LogicException('The createProcess("' . implode(' ', $args[0]) . '", 1200) call wasn\'t expected.');
+				throw new \LogicException('The createProcess("' . implode(' ', $args[0]) . '", 180) call wasn\'t expected.');
 			});
 
 		$this->_commandFactory = $this->_createCommandFactory('', '');
@@ -176,7 +176,7 @@ class CommandFactoryTest extends AbstractTestCase
 		$this->_io->isVerbose()->willReturn(false);
 		$this->_io->isDebug()->willReturn(false);
 
-		$this->_processFactory->createProcess($command, 1200)->willReturn($process)->shouldBeCalled();
+		$this->_processFactory->createProcess($command, 180)->willReturn($process)->shouldBeCalled();
 	}
 
 	/**

--- a/tests/SVNBuddy/Repository/Connector/CommandTest.php
+++ b/tests/SVNBuddy/Repository/Connector/CommandTest.php
@@ -519,7 +519,7 @@ MSG;
 	private function _createCommand(array $command_line, $use_process = true)
 	{
 		if ( $use_process ) {
-			$this->_processFactory->createProcess($command_line, 1200)->willReturn($this->_process)->shouldBeCalled();
+			$this->_processFactory->createProcess($command_line, 180)->willReturn($this->_process)->shouldBeCalled();
 		}
 
 		return new Command(


### PR DESCRIPTION
The executed SVN command idle timeout changed from 20 minutes to 3 minutes.